### PR TITLE
Add naive path filtering

### DIFF
--- a/addons/Todo_Manager/Dock.gd
+++ b/addons/Todo_Manager/Dock.gd
@@ -16,7 +16,7 @@ var plugin : EditorPlugin
 var todo_items : Array
 
 var script_colour := Color("ccced3")
-var ignore_paths := [];
+var ignore_paths := []
 var full_path := false
 var sort_alphabetical := true
 var auto_refresh := true
@@ -42,13 +42,13 @@ func build_tree() -> void:
 	var root := tree.create_item()
 	root.set_text(0, "Scripts")
 	for todo_item in todo_items:
-		var ignore := false;
+		var ignore := false
 		for ignore_path in ignore_paths:
-			if todo_item.script_path.begins_with("res:///" + ignore_path):
-				ignore = true;
-				break;
+			if todo_item.script_path.begins_with("res://" + ignore_path) or todo_item.script_path.begins_with("res:///" + ignore_path):
+				ignore = true
+				break
 		if ignore: 
-			continue;
+			continue
 		var script := tree.create_item(root)
 		if full_path:
 			script.set_text(0, todo_item.script_path + " -------")
@@ -102,14 +102,14 @@ func populate_settings() -> void:
 		pattern_edit.line_edit.connect("text_changed", self, "change_pattern", [i, colour_picker])
 		pattern_edit.remove_button.connect("pressed", self, "remove_pattern", [i, pattern_edit, colour_picker])
 	$VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer4/Patterns/AddPatternButton.raise()
-	var ignore_paths_field := $VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths/TextEdit;
+	var ignore_paths_field := $VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths/TextEdit
 	if !ignore_paths_field.is_connected("text_changed", self, "_on_ignore_paths_changed"):
-		ignore_paths_field.connect("text_changed", self, "_on_ignore_paths_changed");
-	var ignore_paths_text := "";
+		ignore_paths_field.connect("text_changed", self, "_on_ignore_paths_changed")
+	var ignore_paths_text := ""
 	for path in ignore_paths:
-		ignore_paths_text += path + ", ";
-	ignore_paths_text.rstrip(' ').rstrip(',');
-	ignore_paths_field.text = ignore_paths_text;
+		ignore_paths_text += path + ", "
+	ignore_paths_text.rstrip(' ').rstrip(',')
+	ignore_paths_field.text = ignore_paths_text
 
 func rebuild_settings() -> void:
 	for node in colours_container.get_children():
@@ -216,15 +216,16 @@ func _on_Timer_timeout() -> void:
 	print("timer")
 
 func _on_ignore_paths_changed(new_text: String) -> void:
-	var text = $VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths/TextEdit.text;
-	var split: Array = text.split(',');
-	ignore_paths.clear();
+	var text = $VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths/TextEdit.text
+	var split: Array = text.split(',')
+	ignore_paths.clear()
 	for elem in split:
-		if elem == " " || elem == "": continue;
-		ignore_paths.push_front(elem.lstrip(' ').rstrip(' '));
+		if elem == " " || elem == "": 
+			continue
+		ignore_paths.push_front(elem.lstrip(' ').rstrip(' '))
 	# validate so no empty string slips through (all paths ignored)
-	var i := 0;
+	var i := 0
 	for path in ignore_paths:
 		if (path == "" || path == " "):
-			ignore_paths.remove(i);
-		i += 1;
+			ignore_paths.remove(i)
+		i += 1

--- a/addons/Todo_Manager/Dock.gd
+++ b/addons/Todo_Manager/Dock.gd
@@ -46,7 +46,9 @@ func build_tree() -> void:
 		for ignore_path in ignore_paths:
 			if todo_item.script_path.begins_with("res:///" + ignore_path):
 				ignore = true;
-		if ignore: continue;
+				break;
+		if ignore: 
+			continue;
 		var script := tree.create_item(root)
 		if full_path:
 			script.set_text(0, todo_item.script_path + " -------")

--- a/addons/Todo_Manager/Dock.gd
+++ b/addons/Todo_Manager/Dock.gd
@@ -16,6 +16,7 @@ var plugin : EditorPlugin
 var todo_items : Array
 
 var script_colour := Color("ccced3")
+var ignore_paths := [];
 var full_path := false
 var sort_alphabetical := true
 var auto_refresh := true
@@ -41,6 +42,11 @@ func build_tree() -> void:
 	var root := tree.create_item()
 	root.set_text(0, "Scripts")
 	for todo_item in todo_items:
+		var ignore := false;
+		for ignore_path in ignore_paths:
+			if todo_item.script_path.begins_with("res:///" + ignore_path):
+				ignore = true;
+		if ignore: continue;
 		var script := tree.create_item(root)
 		if full_path:
 			script.set_text(0, todo_item.script_path + " -------")
@@ -94,7 +100,14 @@ func populate_settings() -> void:
 		pattern_edit.line_edit.connect("text_changed", self, "change_pattern", [i, colour_picker])
 		pattern_edit.remove_button.connect("pressed", self, "remove_pattern", [i, pattern_edit, colour_picker])
 	$VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer4/Patterns/AddPatternButton.raise()
-
+	var ignore_paths_field := $VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths/TextEdit;
+	if !ignore_paths_field.is_connected("text_changed", self, "_on_ignore_paths_changed"):
+		ignore_paths_field.connect("text_changed", self, "_on_ignore_paths_changed");
+	var ignore_paths_text := "";
+	for path in ignore_paths:
+		ignore_paths_text += path + ", ";
+	ignore_paths_text.rstrip(' ').rstrip(',');
+	ignore_paths_field.text = ignore_paths_text;
 
 func rebuild_settings() -> void:
 	for node in colours_container.get_children():
@@ -112,6 +125,7 @@ func create_config_file() -> void:
 	config.set_value("scripts", "full_path", full_path)
 	config.set_value("scripts", "sort_alphabetical", sort_alphabetical)
 	config.set_value("scripts", "script_colour", script_colour)
+	config.set_value("scripts", "ignore_paths", ignore_paths)
 	
 	config.set_value("patterns", "patterns", patterns)
 	
@@ -126,6 +140,7 @@ func load_config() -> void:
 		full_path = config.get_value("scripts", "full_path", DEFAULT_SCRIPT_NAME)
 		sort_alphabetical = config.get_value("scripts", "sort_alphabetical", DEFAULT_SORT)
 		script_colour = config.get_value("scripts", "script_colour", DEFAULT_SCRIPT_COLOUR)
+		ignore_paths = config.get_value("scripts", "ignore_paths", [])
 		patterns = config.get_value("patterns", "patterns", DEFAULT_PATTERNS)
 		auto_refresh = config.get_value("config", "auto_refresh", true)
 	else:
@@ -197,3 +212,17 @@ func _on_RefreshCheckButton_toggled(button_pressed: bool) -> void:
 func _on_Timer_timeout() -> void:
 	plugin.refresh_lock = false
 	print("timer")
+
+func _on_ignore_paths_changed(new_text: String) -> void:
+	var text = $VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths/TextEdit.text;
+	var split: Array = text.split(',');
+	ignore_paths.clear();
+	for elem in split:
+		if elem == " " || elem == "": continue;
+		ignore_paths.push_front(elem.lstrip(' ').rstrip(' '));
+	# validate so no empty string slips through (all paths ignored)
+	var i := 0;
+	for path in ignore_paths:
+		if (path == "" || path == " "):
+			ignore_paths.remove(i);
+		i += 1;

--- a/addons/Todo_Manager/Dock.tscn
+++ b/addons/Todo_Manager/Dock.tscn
@@ -81,6 +81,7 @@ __meta__ = {
 }
 
 [node name="Settings" type="Panel" parent="VBoxContainer/Panel"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 __meta__ = {

--- a/addons/Todo_Manager/Dock.tscn
+++ b/addons/Todo_Manager/Dock.tscn
@@ -81,7 +81,6 @@ __meta__ = {
 }
 
 [node name="Settings" type="Panel" parent="VBoxContainer/Panel"]
-visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 __meta__ = {
@@ -132,25 +131,25 @@ size_flags_horizontal = 3
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
 margin_top = 28.0
 margin_right = 1014.0
-margin_bottom = 104.0
+margin_bottom = 132.0
 size_flags_horizontal = 5
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer"]
 margin_right = 1014.0
-margin_bottom = 76.0
+margin_bottom = 104.0
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2"]
 margin_right = 50.0
-margin_bottom = 76.0
+margin_bottom = 104.0
 rect_min_size = Vector2( 50, 0 )
 
 [node name="Scripts" type="VBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2"]
 margin_left = 54.0
-margin_right = 529.0
-margin_bottom = 76.0
+margin_right = 545.0
+margin_bottom = 104.0
 
 [node name="ScriptName" type="HBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts"]
-margin_right = 475.0
+margin_right = 491.0
 margin_bottom = 24.0
 
 [node name="Label" type="Label" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/ScriptName"]
@@ -176,7 +175,7 @@ text = "Short name"
 
 [node name="ScriptSort" type="HBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts"]
 margin_top = 28.0
-margin_right = 475.0
+margin_right = 491.0
 margin_bottom = 52.0
 
 [node name="Label" type="Label" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/ScriptSort"]
@@ -210,7 +209,7 @@ text = "(Sorted by full path)"
 
 [node name="ScriptColour" type="HBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts"]
 margin_top = 56.0
-margin_right = 475.0
+margin_right = 491.0
 margin_bottom = 76.0
 
 [node name="Label" type="Label" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/ScriptColour"]
@@ -226,10 +225,35 @@ margin_bottom = 20.0
 rect_min_size = Vector2( 100, 0 )
 color = Color( 0.8, 0.807843, 0.827451, 1 )
 
+[node name="IgnorePaths" type="HBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts"]
+margin_top = 80.0
+margin_right = 491.0
+margin_bottom = 104.0
+
+[node name="Label" type="Label" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths"]
+margin_top = 5.0
+margin_right = 84.0
+margin_bottom = 19.0
+text = "Ignore Paths:"
+
+[node name="TextEdit" type="LineEdit" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths"]
+margin_left = 88.0
+margin_right = 338.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 250, 0 )
+
+[node name="Label3" type="Label" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths"]
+margin_left = 342.0
+margin_top = 5.0
+margin_right = 491.0
+margin_bottom = 19.0
+custom_colors/font_color = Color( 0.392157, 0.392157, 0.392157, 1 )
+text = "(Separated by commas)"
+
 [node name="TODOColours" type="HBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 118.0
+margin_top = 146.0
 margin_right = 1014.0
-margin_bottom = 132.0
+margin_bottom = 160.0
 
 [node name="Label" type="Label" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/TODOColours"]
 margin_right = 95.0
@@ -243,9 +267,9 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 146.0
+margin_top = 174.0
 margin_right = 1014.0
-margin_bottom = 214.0
+margin_bottom = 242.0
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
 margin_right = 50.0
@@ -258,9 +282,9 @@ margin_right = 223.0
 margin_bottom = 68.0
 
 [node name="Patterns" type="HBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 228.0
+margin_top = 256.0
 margin_right = 1014.0
-margin_bottom = 242.0
+margin_bottom = 270.0
 
 [node name="Label" type="Label" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/Patterns"]
 margin_right = 57.0
@@ -274,9 +298,9 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="HBoxContainer4" type="HBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 256.0
+margin_top = 284.0
 margin_right = 1014.0
-margin_bottom = 360.0
+margin_bottom = 388.0
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer4"]
 margin_right = 50.0
@@ -296,9 +320,9 @@ size_flags_horizontal = 0
 text = "Add"
 
 [node name="Config" type="HBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 374.0
+margin_top = 402.0
 margin_right = 1014.0
-margin_bottom = 388.0
+margin_bottom = 416.0
 
 [node name="Label" type="Label" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/Config"]
 margin_right = 43.0
@@ -312,9 +336,9 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="HBoxContainer5" type="HBoxContainer" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
-margin_top = 402.0
+margin_top = 430.0
 margin_right = 1014.0
-margin_bottom = 466.0
+margin_bottom = 494.0
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/Panel/Settings/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer5"]
 margin_right = 50.0
@@ -341,6 +365,7 @@ text = "Reset to default"
 
 [node name="Timer" type="Timer" parent="."]
 one_shot = true
+
 [connection signal="pressed" from="VBoxContainer/Header/HeaderRight/RescanButton" to="." method="_on_RescanButton_pressed"]
 [connection signal="toggled" from="VBoxContainer/Header/HeaderRight/SettingsButton" to="." method="_on_SettingsButton_toggled"]
 [connection signal="item_activated" from="VBoxContainer/Panel/Tree" to="." method="_on_Tree_item_activated"]


### PR DESCRIPTION
## What 

This plugin seems nifty, but to make it fit into my workflow, I needed to be able to filter certain paths to hide any found todos from the item tree. So I made very rudimentary path filtering for my own use.

I thought I'd see if it'd be of any use here. Not sure if this is something that should be integrated into the plugin itself, but I find it's often good to just see if it could be salvaged.

(demo gif at the end for tldr)

## Why

For example, having addons in the project often results in a very bloated TODO view with a lot of unrelated entries.

## How

The implementation is very naive, so it's just an array of strings that are matched with `string.begins_with()` to see if it should be displayed in the tree. So for example, having a value of `addons, scenes/something, assets/two/levels` in the input field would result in anything within `addons` dir to not display, as well as the other two cases. 

There's a potential source of annoyance due to the use of `begins_with`: If the user has folders `scene` and `scenes`, writing down `scene` would also filter out `scenes`. Or if the user has a file `addons_list.txt` in the project root and filtering rule of `addons`, the same happens. To work around this, I found it's best to end directory paths with a trailing `/` but it's not really ideal.

This filtering could also probably do a better job if it was applied earlier in the process, namely when the `todo_items` are gathered. Now it just skips any matches in the tree building part.

You'd also probably want to write this better using regex or something in that vein, but this does the trick for me, and I thought it might be of use. If nothing else, maybe this gives an idea of how to implement this behaviour in a completely different manner, if the idea seems useful for the plugin. The filtering rules, for example, could be written in the same UX as the actual item filtering part of settings and make use of the same components.

![todo-manager-godot-pr-demo](https://user-images.githubusercontent.com/23649183/101417127-d9f73f80-38f3-11eb-922b-e7629049e336.gif)

