### PR TITLE
Fix "Rescan Files" Button overflowing outside the Dock.

### DIFF
--- a/addons/Todo_Manager/UI/Dock.tscn
+++ b/addons/Todo_Manager/UI/Dock.tscn
@@ -426,10 +426,11 @@ one_shot = true
 [node name="RescanButton" type="Button" parent="."]
 anchor_left = 1.0
 anchor_right = 1.0
-margin_left = -97.0
 margin_right = -6.0
 margin_bottom = 20.0
+grow_horizontal = 0
 text = "Rescan Files"
+
 [connection signal="toggled" from="VBoxContainer/Header/HeaderRight/SettingsButton" to="." method="_on_SettingsButton_toggled"]
 [connection signal="tab_changed" from="VBoxContainer/TabContainer" to="." method="_on_TabContainer_tab_changed"]
 [connection signal="item_activated" from="VBoxContainer/TabContainer/Project/Tree" to="." method="_on_Tree_item_activated"]


### PR DESCRIPTION
"Rescan Files" Button overflowed on the right side:
![grafik](https://user-images.githubusercontent.com/17814079/142765687-e727e8de-cb29-4c36-9951-2b60eedfa980.png)
(v3.4.stable.official [206ba70f4] - Apple Silicon, MacOS 11.6, M1)

This little change on the Button fixes the issue for me.
![grafik](https://user-images.githubusercontent.com/17814079/142765698-2e417669-e5bd-4407-ad48-d4c5907791b3.png)
