### PR TITLE
Fixed minimum size broken due to changes in alpha11

### DIFF
--- a/addons/Todo_Manager/UI/ColourPicker.tscn
+++ b/addons/Todo_Manager/UI/ColourPicker.tscn
@@ -5,7 +5,7 @@
 [node name="TODOColour" type="HBoxContainer"]
 offset_right = 105.0
 offset_bottom = 31.0
-script = ExtResource( "1" )
+script = ExtResource("1")
 metadata/_edit_use_custom_anchors = false
 
 [node name="Label" type="Label" parent="."]
@@ -14,8 +14,8 @@ offset_right = 1.0
 offset_bottom = 27.0
 
 [node name="TODOColourPickerButton" type="ColorPickerButton" parent="."]
-minimum_size = Vector2(100, 20)
-offset_left = 5.0
+custom_minimum_size = Vector2(40, 0)
+offset_left = 65.0
 offset_right = 105.0
 offset_bottom = 31.0
 size_flags_horizontal = 10

--- a/addons/Todo_Manager/UI/Dock.tscn
+++ b/addons/Todo_Manager/UI/Dock.tscn
@@ -18,6 +18,10 @@ script = ExtResource("1")
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_top = 4.0
+grow_horizontal = 2
+grow_vertical = 2
+metadata/_edit_layout_mode = 1
 
 [node name="Header" type="HBoxContainer" parent="VBoxContainer"]
 visible = false
@@ -39,10 +43,11 @@ text = "Settings"
 
 [node name="TabContainer" type="TabContainer" parent="VBoxContainer"]
 offset_right = 1024.0
-offset_bottom = 600.0
+offset_bottom = 596.0
 size_flags_vertical = 3
 
 [node name="Project" type="Panel" parent="VBoxContainer/TabContainer"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_top = 31.0
@@ -70,23 +75,23 @@ hide_folding = true
 hide_root = true
 
 [node name="Settings" type="Panel" parent="VBoxContainer/TabContainer"]
-visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_top = 31.0
 
 [node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/TabContainer/Settings"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer"]
-offset_right = 1024.0
-offset_bottom = 600.0
+offset_right = 1016.0
+offset_bottom = 586.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer"]
-offset_right = 1024.0
-offset_bottom = 600.0
+offset_right = 1016.0
+offset_bottom = 586.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -108,24 +113,24 @@ size_flags_horizontal = 3
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
 offset_top = 30.0
 offset_right = 1016.0
-offset_bottom = 166.0
+offset_bottom = 161.0
 size_flags_horizontal = 5
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer"]
 offset_right = 1016.0
-offset_bottom = 136.0
+offset_bottom = 131.0
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2"]
 offset_right = 4.0
-offset_bottom = 136.0
+offset_bottom = 131.0
 
 [node name="Scripts" type="VBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2"]
 offset_left = 8.0
-offset_right = 550.0
-offset_bottom = 136.0
+offset_right = 417.0
+offset_bottom = 131.0
 
 [node name="ScriptName" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts"]
-offset_right = 542.0
+offset_right = 409.0
 offset_bottom = 31.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/ScriptName"]
@@ -151,7 +156,7 @@ text = "Short name"
 
 [node name="ScriptSort" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts"]
 offset_top = 35.0
-offset_right = 542.0
+offset_right = 409.0
 offset_bottom = 66.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/ScriptSort"]
@@ -177,25 +182,25 @@ text = "Reverse Alphabetical"
 
 [node name="ScriptColour" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts"]
 offset_top = 70.0
-offset_right = 542.0
-offset_bottom = 101.0
+offset_right = 409.0
+offset_bottom = 96.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/ScriptColour"]
-offset_top = 2.0
 offset_right = 105.0
-offset_bottom = 28.0
+offset_bottom = 26.0
 text = "Script Colour:"
 
 [node name="ScriptColourPickerButton" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/ScriptColour"]
+custom_minimum_size = Vector2(40, 0)
 offset_left = 109.0
-offset_right = 209.0
-offset_bottom = 31.0
+offset_right = 149.0
+offset_bottom = 26.0
 color = Color(0.8, 0.807843, 0.827451, 1)
 
 [node name="IgnorePaths" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts"]
-offset_top = 105.0
-offset_right = 542.0
-offset_bottom = 136.0
+offset_top = 100.0
+offset_right = 409.0
+offset_bottom = 131.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths"]
 offset_top = 2.0
@@ -204,21 +209,23 @@ offset_bottom = 28.0
 text = "Ignore Paths:"
 
 [node name="TextEdit" type="LineEdit" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths"]
+custom_minimum_size = Vector2(100, 0)
 offset_left = 106.0
-offset_right = 356.0
+offset_right = 206.0
 offset_bottom = 31.0
+expand_to_text_length = true
 
 [node name="Label3" type="Label" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths"]
-offset_left = 360.0
+offset_left = 210.0
 offset_top = 2.0
-offset_right = 542.0
+offset_right = 392.0
 offset_bottom = 28.0
 text = "(Separated by commas)"
 
 [node name="TODOColours" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
-offset_top = 170.0
+offset_top = 165.0
 offset_right = 1016.0
-offset_bottom = 196.0
+offset_bottom = 191.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/TODOColours"]
 offset_right = 114.0
@@ -232,23 +239,23 @@ offset_bottom = 26.0
 size_flags_horizontal = 3
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
-offset_top = 200.0
+offset_top = 195.0
 offset_right = 1016.0
-offset_bottom = 301.0
+offset_bottom = 281.0
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
 offset_right = 4.0
-offset_bottom = 101.0
+offset_bottom = 86.0
 
 [node name="Colours" type="VBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
 offset_left = 8.0
-offset_right = 100.0
-offset_bottom = 101.0
+offset_right = 132.0
+offset_bottom = 86.0
 
 [node name="Patterns" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
-offset_top = 305.0
+offset_top = 285.0
 offset_right = 1016.0
-offset_bottom = 331.0
+offset_bottom = 311.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/Patterns"]
 offset_right = 71.0
@@ -262,9 +269,9 @@ offset_bottom = 26.0
 size_flags_horizontal = 3
 
 [node name="HBoxContainer4" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
-offset_top = 335.0
+offset_top = 315.0
 offset_right = 1016.0
-offset_bottom = 471.0
+offset_bottom = 451.0
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer4"]
 offset_right = 4.0
@@ -284,9 +291,9 @@ size_flags_horizontal = 0
 text = "Add"
 
 [node name="Config" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
-offset_top = 475.0
+offset_top = 455.0
 offset_right = 1016.0
-offset_bottom = 501.0
+offset_bottom = 481.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/Config"]
 offset_right = 54.0
@@ -300,9 +307,9 @@ offset_bottom = 26.0
 size_flags_horizontal = 3
 
 [node name="HBoxContainer5" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer"]
-offset_top = 505.0
+offset_top = 485.0
 offset_right = 1016.0
-offset_bottom = 606.0
+offset_bottom = 586.0
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/HBoxContainer5"]
 offset_right = 4.0

--- a/addons/Todo_Manager/UI/Dock.tscn
+++ b/addons/Todo_Manager/UI/Dock.tscn
@@ -9,11 +9,11 @@
 [sub_resource type="ButtonGroup" id="ButtonGroup_dvci3"]
 
 [node name="Dock" type="Control"]
-minimum_size = Vector2(0, 200)
+custom_minimum_size = Vector2(0, 200)
 anchor_right = 1.0
 anchor_bottom = 1.0
 size_flags_vertical = 3
-script = ExtResource( "1" )
+script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 anchor_right = 1.0
@@ -48,7 +48,7 @@ anchor_bottom = 1.0
 offset_top = 31.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-script = ExtResource( "2" )
+script = ExtResource("2")
 
 [node name="Tree" type="Tree" parent="VBoxContainer/TabContainer/Project"]
 anchor_right = 1.0
@@ -61,7 +61,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-script = ExtResource( "3" )
+script = ExtResource("3")
 
 [node name="Tree" type="Tree" parent="VBoxContainer/TabContainer/Current"]
 anchor_right = 1.0
@@ -80,13 +80,13 @@ anchor_bottom = 1.0
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer"]
 offset_right = 1024.0
-offset_bottom = 606.0
+offset_bottom = 600.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer"]
 offset_right = 1024.0
-offset_bottom = 606.0
+offset_bottom = 600.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -138,7 +138,7 @@ text = "Script Name:"
 offset_left = 104.0
 offset_right = 200.0
 offset_bottom = 31.0
-button_group = SubResource( "ButtonGroup_6rgas" )
+button_group = SubResource("ButtonGroup_6rgas")
 text = "Full path"
 
 [node name="ShortNameCheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/ScriptName"]
@@ -146,7 +146,7 @@ offset_left = 204.0
 offset_right = 323.0
 offset_bottom = 31.0
 button_pressed = true
-button_group = SubResource( "ButtonGroup_6rgas" )
+button_group = SubResource("ButtonGroup_6rgas")
 text = "Short name"
 
 [node name="ScriptSort" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts"]
@@ -165,14 +165,14 @@ offset_left = 90.0
 offset_right = 215.0
 offset_bottom = 31.0
 button_pressed = true
-button_group = SubResource( "ButtonGroup_dvci3" )
+button_group = SubResource("ButtonGroup_dvci3")
 text = "Alphabetical"
 
 [node name="RAlphSortCheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/ScriptSort"]
 offset_left = 219.0
 offset_right = 409.0
 offset_bottom = 31.0
-button_group = SubResource( "ButtonGroup_dvci3" )
+button_group = SubResource("ButtonGroup_dvci3")
 text = "Reverse Alphabetical"
 
 [node name="ScriptColour" type="HBoxContainer" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts"]
@@ -187,7 +187,6 @@ offset_bottom = 28.0
 text = "Script Colour:"
 
 [node name="ScriptColourPickerButton" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/ScriptColour"]
-minimum_size = Vector2(100, 0)
 offset_left = 109.0
 offset_right = 209.0
 offset_bottom = 31.0
@@ -205,7 +204,6 @@ offset_bottom = 28.0
 text = "Ignore Paths:"
 
 [node name="TextEdit" type="LineEdit" parent="VBoxContainer/TabContainer/Settings/ScrollContainer/MarginContainer/VBoxContainer/VBoxContainer/HBoxContainer2/Scripts/IgnorePaths"]
-minimum_size = Vector2(250, 0)
 offset_left = 106.0
 offset_right = 356.0
 offset_bottom = 31.0

--- a/addons/Todo_Manager/UI/Pattern.tscn
+++ b/addons/Todo_Manager/UI/Pattern.tscn
@@ -3,17 +3,16 @@
 [ext_resource type="Script" path="res://addons/Todo_Manager/Pattern.gd" id="1"]
 
 [node name="Pattern" type="HBoxContainer"]
-script = ExtResource( "1" )
+script = ExtResource("1")
 
 [node name="LineEdit" type="LineEdit" parent="."]
-minimum_size = Vector2(200, 0)
-offset_right = 200.0
+offset_right = 67.0625
 offset_bottom = 31.0
 size_flags_horizontal = 0
+expand_to_text_length = true
 
 [node name="RemoveButton" type="Button" parent="."]
-minimum_size = Vector2(24, 24)
-offset_left = 204.0
-offset_right = 228.0
+offset_left = 71.0
+offset_right = 85.0
 offset_bottom = 31.0
 text = "-"

--- a/addons/Todo_Manager/plugin.cfg
+++ b/addons/Todo_Manager/plugin.cfg
@@ -3,5 +3,5 @@
 name="Todo Manager"
 description="Dock for housing TODO messages."
 author="Peter de Vroom"
-version="2.0.0"
+version="2.0.1"
 script="plugin.gd"

--- a/project.godot
+++ b/project.godot
@@ -11,8 +11,8 @@ config_version=5
 [application]
 
 config/name="Todo"
-config/icon="res://icon.png"
 config/features=PackedStringArray("4.0")
+config/icon="res://icon.png"
 
 [editor_plugins]
 


### PR DESCRIPTION
Hey there!

This is a small fix for the dock not showing up properly in alpha11.
This is due to a property change in Control nodes, from `minimum_size` to `custom_minimum_size`.
Tested in Godot 4 alpha 11.