### PR TITLE
Godot 4 Beta 17 hotfix

### DIFF
--- a/addons/Todo_Manager/Dock.gd
+++ b/addons/Todo_Manager/Dock.gd
@@ -184,7 +184,7 @@ func load_config() -> void:
 		full_path = config.get_value("scripts", "full_path", DEFAULT_SCRIPT_NAME)
 		_sort_alphabetical = config.get_value("scripts", "sort_alphabetical", DEFAULT_SORT)
 		script_colour = config.get_value("scripts", "script_colour", DEFAULT_SCRIPT_COLOUR)
-		ignore_paths = config.get_value("scripts", "ignore_paths", [])
+		ignore_paths = config.get_value("scripts", "ignore_paths", [] as Array[String])
 		patterns = config.get_value("patterns", "patterns", DEFAULT_PATTERNS)
 		auto_refresh = config.get_value("config", "auto_refresh", true)
 		builtin_enabled = config.get_value("config", "builtin_enabled", false)

--- a/addons/Todo_Manager/plugin.gd
+++ b/addons/Todo_Manager/plugin.gd
@@ -232,7 +232,7 @@ func rescan_files(clear_cache: bool) -> void:
 	_dockUI.build_tree()
 
 
-func combine_patterns(patterns: Array[Array]) -> String:
+func combine_patterns(patterns: Array) -> String:
 	if patterns.size() == 1:
 		return patterns[0][0]
 	else:


### PR DESCRIPTION
Godot 4 Beta 17 changed how typed arrays work ([GH-69248](https://github.com/godotengine/godot/pull/69248)). This PR solves an error that comes up when an Array of type Array is passed in as an argument. Since this only affects one method, I think removing the typed declaration does not have a significant effect.