### PR TITLE
fixed an error when opening a project

### DIFF
--- a/addons/Todo_Manager/Dock.gd
+++ b/addons/Todo_Manager/Dock.gd
@@ -249,7 +249,8 @@ func case_sensitive_pattern(active: bool, index: int) -> void:
 		patterns[index][2] = CASE_SENSITIVE
 	else:
 		patterns[index][2] = CASE_INSENSITIVE
-	plugin.rescan_files(true)
+	if plugin:
+		plugin.rescan_files(true)
 
 func _on_DefaultButton_pressed() -> void:
 	patterns = DEFAULT_PATTERNS.duplicate(true)


### PR DESCRIPTION
I had this error every time I started a project with the TODO manager:  
`res://addons/Todo_Manager/Dock.gd:252 - Invalid call. Nonexistent function 'rescan_files' in base 'Nil'.`  

I just added `if plugin` before the `plugin.rescan_files()` call in `case_sensitive_pattern()` so it isn't called when the plugin var isn't set yet.  
Didn't test this extensively, but the plugin continues to work fine for me (before the method also didn't get called anyways because of the bug, so...)