### PR TITLE
Add full path tooltip when hovering file name

### DIFF
--- a/addons/Todo_Manager/Project.gd
+++ b/addons/Todo_Manager/Project.gd
@@ -33,6 +33,7 @@ func build_tree(todo_items : Array, ignore_paths : Array, patterns : Array, case
 			script.set_text(0, todo_item.script_path + " -------")
 		else:
 			script.set_text(0, todo_item.get_short_path() + " -------")
+		script.set_tooltip_text(0, todo_item.script_path)
 		script.set_metadata(0, todo_item)
 		for todo in todo_item.todos:
 			var item := tree.create_item(script)


### PR DESCRIPTION
Fixes this issue: https://github.com/OrigamiDev-Pete/TODO_Manager/issues/57.

Preview:

<img width="510" height="178" alt="image" src="https://github.com/user-attachments/assets/09cbdb03-a2ce-4412-950f-4786aa83c981" />
